### PR TITLE
Update `README.md` and add Jupyter book

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -4,7 +4,6 @@ on:
     push:
         branches:
             - main
-            - feat/update_docs_and_details
 
 # This job installs dependencies, build the book, and pushes it to `gh-pages`
 jobs:

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,0 +1,34 @@
+name: deploy-jupyter-book
+
+on:
+    push:
+        branches:
+            - main
+            - feat/update_docs_and_details
+
+# This job installs dependencies, build the book, and pushes it to `gh-pages`
+jobs:
+    deploy-book:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+
+            # Install dependencies
+            - name: Set up Python 3.10
+              uses: actions/setup-python@v4
+              with:
+                  python-version: "3.10"
+
+            - name: Install dependencies
+              run: |
+                  pip install jupyter-book
+            # Build the book
+            - name: Build the book
+              run: |
+                  jupyter-book build notebooks
+            # Push the book's HTML to github-pages
+            - name: GitHub Pages action
+              uses: peaceiris/actions-gh-pages@v3.5.9
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  publish_dir: notebooks/_build/html

--- a/README.md
+++ b/README.md
@@ -1,8 +1,24 @@
 # CellRank 2's reproducibility repository
 
+This repsitory contains the code to reproduce results shown in [_Unified fate mapping in multiview single-cell data_](https://doi.org/10.1101/2023.07.19.549685)
+and has been rendered as a Jupyter book [here](https://theislab.github.io/cellrank2_reproducibility/index.html). All datasets are freely available via CellRank's
+API or [figshare](https://figshare.com/account/home#/projects/88787). If you use our tool in your own work,
+please cite it as
+
+```
+@article{weiler:23,
+    title = {Unified fate mapping in multiview single-cell data},
+    author = {Weiler, Philipp and Lange, Marius and Klein, Michal and Pe{\textquotesingle}er, Dana and Theis, Fabian},
+    doi = {10.1101/2023.07.19.549685},
+    url = {https://doi.org/10.1101/2023.07.19.549685},
+    year = {2023},
+    publisher = {Cold Spring Harbor Laboratory},
+}
+```
+
 ## Installation
 
-### Developer installation
+To run the analyses notebooks locally, clone and install the repository as follows:
 
 ```bash
 conda create -n cr2-py38 python=3.8 --yes && conda activate cr2-py38

--- a/notebooks/_config.yml
+++ b/notebooks/_config.yml
@@ -1,0 +1,9 @@
+title: CellRank 2 reproducibility
+author: Philipp Weiler, Marius Lange, Michal Klein, Dana Pe'er, Fabian Theis
+execute:
+    execute_notebooks: "off"
+
+repository:
+    url: https://github.com/theislab/cellrank2_reproducibility
+html:
+    use_repository_button: true

--- a/notebooks/_toc.yml
+++ b/notebooks/_toc.yml
@@ -1,0 +1,43 @@
+format: jb-book
+root: index
+parts:
+    - caption: PseudotimeKernel
+      chapters:
+          - file: pseudotime_kernel/dpt
+          - file: pseudotime_kernel/rna_velocity
+    - caption: CytoTRACEKernel
+      chapters:
+          - file: cytotrace_kernel/benchmark/README
+            sections:
+                - file: cytotrace_kernel/benchmark/runtime
+                - file: cytotrace_kernel/benchmark/cytotrace_vs_cr2_scores
+          - file: cytotrace_kernel/embryoid_body/README
+            sections:
+                - file: cytotrace_kernel/benchmark/cytotrace
+                - file: cytotrace_kernel/benchmark/dpt
+                - file: cytotrace_kernel/benchmark/palantir
+    - caption: RealTimeKernel
+      chapters:
+          - file: realtime_kernel/mef/README
+            sections:
+                - file: realtime_kernel/mef/realtime_informed_pseudotime
+                - file: realtime_kernel/mef/dpt
+                - file: realtime_kernel/mef/palantir
+                - file: realtime_kernel/mef/wot
+          - file: realtime_kernel/pharyngeal_endoderm/README
+            sections:
+                - file: realtime_kernel/pharyngeal_endoderm/realtimekernel_full_data
+                - file: realtime_kernel/pharyngeal_endoderm/realtimekernel_subsetted_data
+                - file: realtime_kernel/pharyngeal_endoderm/wot_subsetted_data
+    - caption: Metabolic labeling
+      chapters:
+          - file: labeling_kernel/preprocessing
+          - file: labeling_kernel/inference
+          - file: labeling_kernel/fate_mapping
+          - file: labeling_kernel/velocity_pseudotime
+          - file: labeling_kernel/kinetic_rate_change
+          - file: labeling_kernel/rna_velocity/em_model
+          - file: labeling_kernel/dynamo/velo_chase_and_pulse
+          - file: labeling_kernel/dynamo/fp_ana_chase_and_pulse
+          - file: labeling_kernel/dynamo/lap_chase_and_pulse
+          - file: labeling_kernel/method_comparison

--- a/notebooks/cytotrace_kernel/benchmark/README.md
+++ b/notebooks/cytotrace_kernel/benchmark/README.md
@@ -1,0 +1,4 @@
+# Benchmark
+
+To benchmark our implementation of the CytoTRACE method, we compared the runtime to the original method with increasing sample size,
+and confirmed that the computed scores correlate significantly.

--- a/notebooks/cytotrace_kernel/embryoid_body/README.md
+++ b/notebooks/cytotrace_kernel/embryoid_body/README.md
@@ -1,0 +1,3 @@
+# Embryoid body development
+
+The _CytoTRACEKernel_ recovers the differentiation landscape and pattern of embryoid body development.

--- a/notebooks/index.md
+++ b/notebooks/index.md
@@ -1,0 +1,34 @@
+# CellRank 2's reproducibility repository
+
+This repsitory contains the code to reproduce results shown in [_Unified fate mapping in multiview single-cell data_](https://doi.org/10.1101/2023.07.19.549685)
+and has been rendered as a Jupyter book [here](https://theislab.github.io/cellrank2_reproducibility/index.html). All datasets are freely available via CellRank's
+API or [figshare](https://figshare.com/account/home#/projects/88787). If you use our tool in your own work,
+please cite it as
+
+```
+    @article{weiler:23,
+        title = {Unified fate mapping in multiview single-cell data},
+        author = {Weiler, Philipp and Lange, Marius and Klein, Michal and Pe{\textquotesingle}er, Dana and Theis, Fabian},
+        doi = {10.1101/2023.07.19.549685},
+        url = {https://doi.org/10.1101/2023.07.19.549685},
+        year = {2023},
+        publisher = {Cold Spring Harbor Laboratory},
+    }
+```
+
+## Installation
+
+To run the analyses notebooks locally, clone and install the repository as follows:
+
+```bash
+conda create -n cr2-py38 python=3.8 --yes && conda activate cr2-py38
+pip install -e ".[dev]"
+pre-commit install
+```
+
+Jupyter lab and the corresponding kernel can be installed with
+
+```bash
+pip install jupyterlab ipywidgets
+python -m ipykernel install --user --name cr2-py38 --display-name "cr2-py38"
+```

--- a/notebooks/realtime_kernel/mef/README.md
+++ b/notebooks/realtime_kernel/mef/README.md
@@ -1,0 +1,5 @@
+# Analysis of mouse embryonic fibroblasts
+
+Many applications, including gene trend plotting and driver gene identification, require continuous information on continuous state chage. Thus, we comprised a
+new, real-time-informed pseudotime approach, which embeds the experimental time points in the continuous landscape of expression changes. We compare this new
+pseudotime to the well-established methods DPT and Palantir, and highlight the inherently discrete gene expression change considered in classical OT.

--- a/notebooks/realtime_kernel/pharyngeal_endoderm/README.md
+++ b/notebooks/realtime_kernel/pharyngeal_endoderm/README.md
@@ -1,0 +1,4 @@
+# Analysis of pharyngeal endoderm development
+
+We showcase the _RealTimeKernel_ and highlight the importance of considering within-time-point information by studying mTEC development
+in pharyngeal endoderm development.


### PR DESCRIPTION
## Changes

<!-- Please remove section if this PR does change an existing feature -->

- Updates `README.md` to include reference to CellRank 2 preprint and rendered Jupyter book, and information on where to obtain used data from.
- Adds `realtime_kernel/mef/README.md`
- Adds `realtime_kernel/pharyngeal_endoderm/README.md`
- Adds `cytotrace_kernel/benchmark/README.md`
- Adds `cytotrace_kernel/embryoid_body/README.md`

## New

- Adds Jupyter book setup
- Adds GitHub action workflow `book.yml` to build Jupyter book

## Related issues

<!-- Please list related issues. If none exist, open one and reference it here. -->

Closes #37.
