### PR TITLE
Add `lint.yml`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: Lint
+
+on:
+    push:
+        branches: main
+    pull_request:
+        branches: main
+
+jobs:
+    linting:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - name: Setup Python 3.10
+              uses: actions/setup-python@v4
+              with:
+                  python-version: "3.10"
+            - name: Install dependencies
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install pre-commit
+            - name: Check pre-commit compatibility
+              run: pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
Adds CI to check linting on push to `main` or when opeing a PR to merge into `main`.

## New

<!-- Please give section if this PR does not implement a new feature -->

- Add `.github/workflows/lint.yml` to check linting of files.

## Related issues

<!-- Please list related issues. If none exist, open one and reference it here. -->

Closes #39.
