### PR TITLE
Update `labeling_kernel/inference.ipynb`

### DIFF
--- a/notebooks/labeling_kernel/inference.ipynb
+++ b/notebooks/labeling_kernel/inference.ipynb
@@ -209,6 +209,7 @@
     "    time_key=\"labeling_time\",\n",
     "    experiment_key=\"experiment\",\n",
     "    n_neighbors=n_neighbors,\n",
+    "    x0=None,\n",
     "    n_jobs=N_JOBS,\n",
     ")\n",
     "\n",

--- a/scripts/labeling_kernel/inference.py
+++ b/scripts/labeling_kernel/inference.py
@@ -94,6 +94,7 @@ alpha, gamma, r0, success, opt_res = get_parameters(
     time_key="labeling_time",
     experiment_key="experiment",
     n_neighbors=n_neighbors,
+    x0=None,
     n_jobs=N_JOBS,
 )
 


### PR DESCRIPTION
Specify initial parameter estimate as `None`.

## Bug fixes

<!-- Please give section if this PR does not fix any bugs -->

- Specify `x0` for parameter inference.

## Related issues

<!-- Please list related issues. If none exist, open one and reference it here. -->

Closes #61.
